### PR TITLE
Update configure-cdn.md

### DIFF
--- a/power-pages-docs/configure/configure-cdn.md
+++ b/power-pages-docs/configure/configure-cdn.md
@@ -27,6 +27,7 @@ When you enable Content Delivery Network on your portal, static content&mdash;li
 > - You need to be a [website administrator](/power-apps/maker/portals/admin/portal-admin-roles#required-roles-and-permissions) to enable Content Delivery Network. This feature is available for Power Pages. If you're using the legacy Add-on license, you can't enable Content Delivery Network. Trial websites aren't supported for Content Delivery Network. 
 > - [Restricting website access by IP address](../admin/ip-address-restrict.md) on a site is currently not supported with using Content Delivery Network.
 > - This service is not available in Government Community Cloud (GCC), Government Community Cloud (GCC High), Department of Defense (DoD), and UAE region.
+> - Setting a custom certificate is not supported with using Content Delivery Network, since the certificate will be managed by the CDN team. 
 
 ## Enable Content Delivery Network for a production website 
 


### PR DESCRIPTION
Added a note about custom certificates not supported when using CDN. This info was received from MS Support:
"Unfortunately , there is no way to manage custom certificates when CDN is enabled. Because when CDN is enabled , the certificate will be managed by CDN team. As there is no documentation as of today for this. On my request, our dev confirmed that he is going to get this documented tentatively in 2 weeks. I also informed that I'll share the document as soon as I get it from devs of product group."