### PR TITLE
update: AI Feature article link title

### DIFF
--- a/power-pages-docs/configure/ai-copilot-overview.md
+++ b/power-pages-docs/configure/ai-copilot-overview.md
@@ -39,7 +39,7 @@ To learn how to use the new AI features in Power Pages, see:
 - [Create an AI-generated webpage using Copilot (preview)](../getting-started/create-page-copilot.md)
 - [Add an AI-generated form using Copilot (preview)](../getting-started/add-form-copilot.md)
 - [Add an AI-generated multistep form using Copilot (preview)](../getting-started/multistep-forms-copilot.md)
-- [Use Copilot to generate text and it to a webpage (preview)](../getting-started/add-text-copilot.md)
+- [Add AI-generated text using Copilot (preview)](../getting-started/add-text-copilot.md)
 - [Enable chatbot in Power Pages site (preview)](../getting-started/enable-chatbot.md)
 - [Force Bing webmaster to index your site (preview)](../getting-started/force-bing-index.md)
 - [Add AI-generated code using Copilot (preview)](add-code-copilot.md)

--- a/power-pages-docs/configure/ai-copilot-overview.md
+++ b/power-pages-docs/configure/ai-copilot-overview.md
@@ -40,7 +40,7 @@ To learn how to use the new AI features in Power Pages, see:
 - [Add an AI-generated form using Copilot (preview)](../getting-started/add-form-copilot.md)
 - [Add an AI-generated multistep form using Copilot (preview)](../getting-started/multistep-forms-copilot.md)
 - [Add AI-generated text using Copilot (preview)](../getting-started/add-text-copilot.md)
-- [Enable chatbot in Power Pages site (preview)](../getting-started/enable-chatbot.md)
+- [Add an AI-powered chatbot (preview)](../getting-started/enable-chatbot.md)
 - [Force Bing webmaster to index your site (preview)](../getting-started/force-bing-index.md)
 - [Add AI-generated code using Copilot (preview)](add-code-copilot.md)
 


### PR DESCRIPTION
Some article link where not using correct title.

All of the other titles use the article name in their title except two.