### PR TITLE
Microsoft Authentication Provider - Client Secret correction

### DIFF
--- a/power-pages-docs/security/authentication/oauth2-microsoft.md
+++ b/power-pages-docs/security/authentication/oauth2-microsoft.md
@@ -68,7 +68,7 @@ Set Microsoft as an identity provider for your site.
 
 1. Enter an optional description, select an expiration, and then select **Add**.
 
-1. Under **Secret ID**, select the **Copy to clipboard** icon.
+1. Under **Secret Value**, select the **Copy to clipboard** icon.
 
 ## Enter site settings in Power Pages
 
@@ -77,7 +77,7 @@ Set Microsoft as an identity provider for your site.
 1. Under **Configure site settings**, paste the following values:
 
     - **Client ID​**: Paste the **Application (client) ID** [you copied](#create-a-microsoft-app-registration-in-azure).
-    - **Client secret**: Paste the **Secret ID** you copied.
+    - **Client secret**: Paste the **Secret Value** you copied.
 
 [Optional additional settings for OAuth 2.0 identity providers](oauth2-settings.md)
 


### PR DESCRIPTION
Correcting Article on Microsoft Authentication Provider. It said to use the secret id as client secret, but by own testing and [this discussion](https://powerusers.microsoft.com/t5/General-Discussions/Microsoft-LogIn-Unable-to-authenticate-with-external-account/m-p/2363622/highlight/true#M4637) this is wrong.

Correct setup:
![2024-06-29_20h29_01](https://github.com/MicrosoftDocs/power-pages-docs/assets/9168648/a7bcba7f-80c2-41bd-9993-5539acf36f22)
![2024-06-29_20h29_12](https://github.com/MicrosoftDocs/power-pages-docs/assets/9168648/b7aa7010-724b-4015-b976-cd42e277eb80)