### PR TITLE
Add workaround tip for an issue with creating sites

### DIFF
--- a/power-pages-docs/getting-started/create-manage.md
+++ b/power-pages-docs/getting-started/create-manage.md
@@ -46,6 +46,9 @@ Use the Power Pages design studio to customize and design your site.
 
 1. After you find the best template for your business needs, select **Choose this template**.
 
+    > [!TIP]
+    > If you encounter an error message that reads "Sorry, there's been a disconnect", navigate to Power Pages in your environment via `https://make.powerpages.microsoft.com/environments/{environment_id}/portals/home`, replacing `{environment_id}` with your environment ID. From there, you can choose "Start with a template" or "Start from blank" to create your site.
+  
 1. Check the default site name and web address, and then select **Done**.
 
     :::image type="content" source="media/default-template/provision-site.png" alt-text="The design studio with site provisioning options displayed.":::


### PR DESCRIPTION
Based on the issue outlined in [Community Idea: Improve the microsoft learn page for creating a powerpages site](https://ideas.powerpages.microsoft.com/d365community/idea/3b5475ec-e225-f011-9d48-7c1e52b0e305):

> This is an idea to update the Microsoft learn page (https://learn.microsoft.com/en-us/power-pages/getting-started/create-manage) for provisioning a new power pages site to cover the following situation. 
>  
> In my case site provisioning failed when I 
> 1) navigated to https://make.powerpages.microsoft.com/
> 2) Click Get Started
> 3) Select template OR select Skip
> 4) I get the error message Sorry, there's been a disconnect.
>  
> I implemented the following workaround with Microsoft's support. 
> 1. Navigate to https://make.powerpages.microsoft.com/environments/EnvironmnetGUID/portals/home.  Note EnvironmnetGUID is to be replaced with your environment id (from your environment url).
> 2. Choose Start with a Template OR Start from blank to create your site.
 